### PR TITLE
fix: if condition which bypass null or undefined also bypassed zero

### DIFF
--- a/packages/no-alias/src/index.ts
+++ b/packages/no-alias/src/index.ts
@@ -168,7 +168,7 @@ function checkCount(
   const fieldKey = `${typeKey}.${nodeName}`
   const maxAllowed = maxAllowedData.get(fieldKey) || maxAllowedData.get(typeKey)
 
-  if (maxAllowed) {
+  if (typeof maxAllowed === 'number' && isFinite(maxAllowed)) {
     let currentCount = currentCountData.get(fieldKey) ?? 0
     currentCount++
     if (currentCount > maxAllowed) {


### PR DESCRIPTION
When the developer is trying to use something like:

```javascript
const validation = createValidation({
  permissions: { Query: { '*': 0 }, Mutation: { '*': 0 } },
})
```

We expect this rule will let the system could not use any alias, but what actually happen, due to the line `if (maxAllowed) {`, when the number comes to zero, this will actually bypass the validation, which means zero does not count as a available number in this case, which......I don't think its correct.

So what i do is to change the if condition to check "if maxAllowed is really a number", which should fix the problem.